### PR TITLE
Fix ReflectionObject::getMethods() filters

### DIFF
--- a/src/Traits/WithComputedProperties.php
+++ b/src/Traits/WithComputedProperties.php
@@ -20,7 +20,7 @@ trait WithComputedProperties
 
         $methods = array_filter(
             $object->getMethods(
-                ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED | ReflectionMethod::IS_PUBLIC
+                ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED | ReflectionMethod::IS_PRIVATE
             ), function (ReflectionMethod $method) {
                 return count($method->getAttributes(Computed::class)) > 0;
             }


### PR DESCRIPTION
The filter `ReflectionMethod::IS_PUBLIC` is duplicated in the argument. I assume `ReflectionMethod::IS_PRIVATE` was actually meant to be there instead.